### PR TITLE
fix account offset

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,8 @@ pub unsafe extern "C" fn entrypoint(mut input: *mut u8) -> u32 {
         // Load num accounts (r9 will be used to move into num_accounts stack..)
         "ldxdw r9, [r1 + 0]",
         "mov64 r5, r9",
-
+        // Advance input cursor by num accounts
+        "add64 r1, 8",
         // Initialize accounts cursor
         "lddw r7, {accounts_ptr}",
 
@@ -56,7 +57,7 @@ pub unsafe extern "C" fn entrypoint(mut input: *mut u8) -> u32 {
         "2:",
         // Otherwise, increment account cursor, load dup marker, jump to dup if dup
         "add64 r7, 8",
-        "ldxb r6, [r1 + 8]",
+        "ldxb r6, [r1 + 0]",
         "jne r6, 255, 5f",
 
         // Non-duplicate account case
@@ -91,7 +92,6 @@ pub unsafe extern "C" fn entrypoint(mut input: *mut u8) -> u32 {
 
         // Finished
         "6:",
-        "add64 r1, 8",
 
 
         inout("r1") input,


### PR DESCRIPTION
### Issue

The code treats the input pointer (r1) as if it's already pointing to the first account but it's actually pointing to the account count. When logged, the parsed accounts don't match those sent in the input instruction.

### Fix

Advance r1 by num accounts (8) before doing other operations.

### Logs

**Before**

<img width="1449" height="784" alt="Screenshot 2025-08-03 at 3 08 03 PM" src="https://github.com/user-attachments/assets/1e64f824-146c-463b-a502-eed976ad4394" />

**After**

<img width="1449" height="784" alt="Screenshot 2025-08-03 at 3 02 48 PM" src="https://github.com/user-attachments/assets/33b4dc68-7990-469c-8731-a8e4f7e8a7ab" />

### Notes

- This branch doesn't contain any logs but they can be found in this  [branch](https://github.com/bidhan-a/asmr/tree/fix/accounts-with-log).
- No change in CUs.
